### PR TITLE
Update README: override default import in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ In `+layout.svelte` for client-side usage:
 
 ```sveltehtml
 <script lang="ts">
-    import { loadPlugins } from 'sveltekit-plugin-system';
-    loadPlugins();
+	import { loadPlugins } from 'sveltekit-plugin-system';
+	loadPlugins();
 </script>
 
 <slot />
@@ -54,8 +54,8 @@ Placed after `<slot />`, the plugins can now inject components after the slot co
 
 ```sveltehtml
 <script lang="ts">
-    import {loadPlugins, Hook} from "sveltekit-plugin-system";
-    loadPlugins();
+	import {loadPlugins, Hook} from "sveltekit-plugin-system";
+	loadPlugins();
 </script>
 
 <slot />
@@ -89,11 +89,11 @@ In our `+layout.svelte` file, we will add the `doAction` function from `hooks` s
 
 ```sveltehtml
 <script lang="ts">
-    import { loadPlugins, hooks } from "sveltekit-plugin-system";
+	import { loadPlugins, hooks } from "sveltekit-plugin-system";
 
-    loadPlugins()
+	loadPlugins()
 
-    $: hooks.doAction('log-something') // Action hook
+	$: hooks.doAction('log-something') // Action hook
 </script>
 
 <slot />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "sveltekit-plugin-system",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && npm run package",


### PR DESCRIPTION
# Description
The default global import appears to be malfunctioning. The README has been updated to instruct users to add it manually.

# Changes Made
[doc] Updated README with instructions for manual plugins import.